### PR TITLE
$cardinality boolean flag named :closed, not :total

### DIFF
--- a/src/automata/nurse_scheduling.clj
+++ b/src/automata/nurse_scheduling.clj
@@ -114,7 +114,7 @@
     ($cardinality column {day minimum-day-shifts
                           night minimum-night-shifts
                           nothing (- n-nurses minimum-day-shifts minimum-night-shifts)}
-                  :total true)))
+                  :closed true)))
 
 (defn solve-nurse-shifts
   []


### PR DESCRIPTION
Hi !
Thx for the great lib Loco and nice examples .
Maybe a typo in the $cardinality clause of the nurses ?
Cf. https://github.com/aengelberg/loco/blob/master/src/loco/constraints.clj#L626
